### PR TITLE
Fix search index field and loading check

### DIFF
--- a/themes/coyote/assets/js/search.js
+++ b/themes/coyote/assets/js/search.js
@@ -10,7 +10,7 @@ const fuseOptions = {
   minMatchCharLength: 1,
   keys: [
     {name:"title",weight:0.8},
-    {name:"contents",weight:0.5},
+    {name:"content",weight:0.5},
     {name:"tags",weight:0.3},
     {name:"categories",weight:0.3}
   ]
@@ -29,6 +29,9 @@ const input = document.getElementById('searchInput')
 const results = document.getElementById('searchResults')
 
 input.addEventListener('keyup', (e) => {
+  if (!fuse) {
+    return
+  }
   const items = fuse.search(e.target.value)
 
   if (items.length > 0) {


### PR DESCRIPTION
## Summary
- fix search results by looking up correct `content` field
- prevent runtime error if search runs before index loads

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffd9cdeb48331a6caed6e100fc546