### PR TITLE
Implement pagination for index and list pages

### DIFF
--- a/themes/coyote/layouts/_default/list.html
+++ b/themes/coyote/layouts/_default/list.html
@@ -11,7 +11,8 @@
 
   <div class="results">
     {{- $pages := union .RegularPages .Sections }}
-    {{ range $pages }}
+    {{- $paginator := .Paginate $pages }}
+    {{ range $paginator.Pages }}
     <div class="resultItem">
       <div class="resultItem__media" style="background-image: url({{ (print .Permalink .Params.image) | absURL }});"></div>
       <div class="resultItem__body">
@@ -21,5 +22,8 @@
     </div>
     {{ end }}
   </div>
+  {{- if gt $paginator.TotalPages 1 }}
+    {{- partial "pagination.html" $paginator -}}
+  {{- end }}
 </section>
 {{- end }}

--- a/themes/coyote/layouts/index.html
+++ b/themes/coyote/layouts/index.html
@@ -11,7 +11,7 @@
   </section>
 
   {{- if gt $paginator.TotalPages 1 }}
-    {{- partial "pagination.html" . -}}
+    {{- partial "pagination.html" $paginator -}}
   {{- end }}
 
 {{ end }}

--- a/themes/coyote/layouts/partials/pagination.html
+++ b/themes/coyote/layouts/partials/pagination.html
@@ -1,6 +1,5 @@
 <div class="pagination">
-  {{- $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}
-  {{- $paginator := .Paginate $pages }}
+  {{- $paginator := . }}
 
   {{ range $paginator.Pagers }}
     <div class="pagination__item">


### PR DESCRIPTION
## Summary
- add pagination snippet that accepts a paginator
- paginate index listing using new snippet
- paginate tag/category lists similarly

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffd9bc7c88331aa80a1ae4079512c